### PR TITLE
set correct user and group id upon .env file generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ up:
 init: .env data/oxideshop/ permissions data/oxideshop/vendor/ data/oxideshop/source/config.inc.php up reset
 
 .env: .env.dist
-	if [ ! -f .env ]; then cp .env.dist .env; fi
+	if [ ! -f .env ]; then \
+		cp .env.dist .env; \
+		sed -i s/HOST_USER_ID=1000/HOST_USER_ID=`id -u`/ .env; \
+		sed -i s/HOST_GROUP_ID=1000/HOST_GROUP_ID=`id -g`/ .env; \
+	fi
+
 
 composer: data/oxideshop/vendor/
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ The profiles and traces from xDebug will be dumped to `data/oxideshop/debug/` di
 
 ## Troubleshooting
 
+### Permission problems
+
+When you see `composer install` or `composer update` failing due to permission problems, it might be that your `HOST_USER_ID` and `HOST_GROUP_ID` values in `.env` file are wrong. The `make  init` step tries to use the `/usr/bin/id` command to get the correct values, but could fail doing so.
+
+To recover from this you need to set the correct `HOST_USER_ID` and `HOST_GROUP_ID` values in `.env` file and then `docker-composer build --no-cache` to enforce a rebuild of the container.
+
 ### Port conflicts
 
 If any ports are already in use on your host you might need to change the bindings in the "ports:" section of the affected service.


### PR DESCRIPTION
Hey there :vulcan_salute:,

as it turns out, not every Linux uses the user and group ID 1000 for the default first user. Ubuntu for example might give you the user and group ID 1001. As we do not know what the user and group IDs are, we can use the `/usr/bin/id` command to query for them.

This pull request adds this feature.

/Flo