### PR TITLE
Bump xDebug version to 3.0.0

### DIFF
--- a/build/php/xdebug.ini
+++ b/build/php/xdebug.ini
@@ -1,9 +1,6 @@
-xdebug.remote_enable = on
-xdebug.remote_connect_back = on
-xdebug.idekey = PHPSTORM
-xdebug.remote_autostart = off
-xdebug.remote_port = 9001
-xdebug.trace_enable_trigger = true
-xdebug.trace_output_dir = /var/www/oxideshop/debug/
-xdebug.profiler_enable_trigger = true
-xdebug.profiler_output_dir = /var/www/oxideshop/debug/
+xdebug.mode = debug,trace,profile
+xdebug.start_with_request  = trigger
+xdebug.trigger_value = PHPSTORM
+xdebug.discover_client_host = true
+xdebug.client_port = 9001
+xdebug.output_dir = /var/www/oxideshop/debug/


### PR DESCRIPTION
xDebug `3.0.0` has been finally release today
https://xdebug.org/announcements/2020-11-25

This PR updates the PHP `Dockerfile` to use xDebug `3.0.0` and also the configuration file to the new config options.