### PR TITLE
Update to be able to switch between selenium images

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -12,5 +12,7 @@ HOST_GROUP_ID=1000
 PHP_VERSION=7.3
 DATABASE_IMAGE=mysql:5.7
 PHP_HOST_IP=172.17.0.1
-#possible versions https://hub.docker.com/r/oxidesales/oxideshop-docker-selenium/tags
-SELENIUM_FIREFOX=S3FF77
+#possible oxid versions https://hub.docker.com/r/oxidesales/oxideshop-docker-selenium/tags
+# or headless chrome selenium/standalone-chrome:3.141.59
+SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - internal
 
   selenium:
-    image: oxidesales/oxideshop-docker-selenium:${SELENIUM_FIREFOX}
+    image: ${SELENIUM_IMAGE}
     restart: always
     depends_on:
       - php


### PR DESCRIPTION
Right now it was only possible to switch between firefox tags within the oxid selenium image tags.
Changed to be able to put in every selenium image you want. 
Might break tests while choosing the wrong image 
![image](https://user-images.githubusercontent.com/35966734/102229437-1a564f00-3eec-11eb-83df-6187414a08e7.png)
