### PR TITLE
Allow slightly longer time for the mysql health check

### DIFF
--- a/services/mysql.yml
+++ b/services/mysql.yml
@@ -9,7 +9,7 @@
     healthcheck:
       test: out=$$(mysqladmin ping -h localhost -P 3306 -u root --password=$${MYSQL_ROOT_PASSWORD} 2>&1); echo $$out | grep 'mysqld is alive' || { echo $$out; exit 1; }
       interval: 1s
-      retries: 30
+      retries: 60
     volumes:
       - ./data/mysql:/var/lib/mysql:delegated
     ports:


### PR DESCRIPTION
It looks like the mysql containers are failing randomly because of the 30s timeout (8.0 more often than 5.7). Especially, when there is some load in the cluster.

Increasing the maximum time for the health check from 30s to 1 Minute should stabilize the private runner builds