### PR TITLE
Add pinned selenium image for v 126.0

### DIFF
--- a/services/selenium-chrome-126.yml
+++ b/services/selenium-chrome-126.yml
@@ -1,0 +1,19 @@
+  selenium:
+    platform: linux/x86_64
+    image: 'selenium/standalone-chrome:126.0-chromedriver-126.0'
+    restart: always
+    shm_size: 500M
+    depends_on:
+      - php
+    healthcheck:
+      test: /opt/bin/check-grid.sh
+      interval: 1s
+      retries: 60
+    ports:
+      - 4444:4444
+      - 5900:5900
+    links:
+      - "apache:localhost.local"
+      - "apache:oxideshop.local"
+    volumes:
+      - ./source:/var/www:cached


### PR DESCRIPTION
The latest selenium-chrome image breaks the oxideshop codeception tests, while v126.0 works fine. This PR adds a selenium-chrome-126 service that can be used instead of the selenium-chome service which uses the "latest" tag.