### PR TITLE
Bugtracker-7794 add higher default timeout definition

### DIFF
--- a/containers/httpd/project.conf.dist
+++ b/containers/httpd/project.conf.dist
@@ -21,3 +21,6 @@ DocumentRoot "/var/www/"
     Protocols h2 http/1.1
 
 </VirtualHost>
+
+# For local development with Xdebug, it's convenient to have a longer timeout than the default.
+Timeout 600


### PR DESCRIPTION
As a developer, I want to easily debug my OXID project and quickly get the information I need to fix issues during development.

By default, Apache uses a timeout of 60 seconds. When using Xdebug, it's common to exceed this timeout because you’re stepping through the code or inspecting values in your IDE. When you return to the browser, Apache has already sent a timeout response, and you're forced to reload the page. In many cases, this means starting over — navigating through multiple steps just to reach the state you were debugging.

The small change proposed in this Pull Request sets a longer timeout by default for new OXID project setups. This improves the developer experience by preventing unnecessary interruptions and allows developers to focus on solving the actual problem, not fighting infrastructure defaults.