### PR TITLE
Add test ports helper in the Makefile file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed the deprecated image selenium/standalone-chrome-debug:3.141.59 to selenium/standalone-chrome:latest
 - Confirmation question on `cleanup` command to avoid accidental data loss
 - Redis container preconfigured and ready to use if needed
+- Add Makefile command `make test_ports` to check if some of the configured ports are already in use [PR-38](https://github.com/OXID-eSales/docker-eshop-sdk/pull/38)
 
 ### Changed
 - Default Nginx configuration directory changed to fit development practices

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,17 @@ down:
 php:
 	docker compose exec php bash
 
+ .PHONY: test_ports ## Test if ports defined in .env file are available (netcat needed!)
+test_ports:
+	$(if $(shell if [ -f .env ]; then echo '.env exists'; fi), , $(error Please create .env file with make setup))
+	@for port_line in $$(grep ^PORT_ .env) ; \
+	    do port=$$(echo $$port_line | cut -d = -f 2 );\
+	       port_name=$$(echo $$port_line | cut -d = -f 1 );\
+	       if netcat -z localhost $$port ; then \
+	        echo $$port for $$port_name is NOT available ;\
+	       fi \
+	    done
+
 generate-docs:
 	docker compose run --rm sphinx sphinx-build /home/$(USERNAME)/docs /home/$(USERNAME)/docs/build
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test_ports:
 	@for port_line in $$(grep ^PORT_ .env) ; \
 	    do port=$$(echo $$port_line | cut -d = -f 2 );\
 	       port_name=$$(echo $$port_line | cut -d = -f 1 );\
-	       if netcat -z localhost $$port ; then \
+	       if nc -z localhost $$port ; then \
 	        echo $$port for $$port_name is NOT available ;\
 	       fi \
 	    done


### PR DESCRIPTION
With this MR it will be possible for the developer to call `make test_ports`  in order to see which port defined in the `.env` are available or not.

For example when a port is not available (meaning another service is using it) the output will be something like:
```
Connection to localhost (::1) 8065 port [tcp/*] succeeded!
8065 for PORT_SHOP is NOT available
```

When all ports are available, nothing is displayed.